### PR TITLE
Change to Signed Statements for Hashed Payloads (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,65 @@
 # GitHub Action for creating and registering SCITT statements with Software Trust Manager and DataTrails
 
-This GitHub Action provides the ability to create and sign [SCITT](https://datatracker.ietf.org/wg/scitt/about/) statements using code signing keys protected by DigiCert [Software Trust Manager](https://www.digicert.com/software-trust-manager) and submit these statements to the transparency service operated by [DataTrails](https://www.datatrails.ai/).
+This GitHub Action provides the ability to create and sign [SCITT](https://datatracker.ietf.org/wg/scitt/about/) statements using code signing keys protected by DigiCert [Software Trust Manager](https://www.digicert.com/software-trust-manager) and register these statements to a SCITT transparency service operated by [DataTrails](https://www.datatrails.ai/).
+
+**NOTE:**:  
+This SCITT GitHub Action is in Preview, pending adoption of the [SCITT Reference APIs (SCRAPI)](https://datatracker.ietf.org/doc/draft-ietf-scitt-scrapi/).
+To use a production supported implementation, please contact [DataTrails](https://www.datatrails.ai/contactus/) for more info.
 
 ## Getting Started
 
 1. Generate a keypair and corresponding end-entity certificate in [Software Trust Manager](https://www.digicert.com/software-trust-manager)
-2. [Create an account](https://app.datatrails.ai/signup) at DataTrails and [create an access token](https://docs.datatrails.ai/developers/developer-patterns/getting-access-tokens-using-app-registrations/)
+1. [Create an account](https://app.datatrails.ai/signup) at DataTrails and [create an access token](https://docs.datatrails.ai/developers/developer-patterns/getting-access-tokens-using-app-registrations/)
+1. Configure a GitHub SCITT Action, with the following [Inputs](#action-inputs) and [Example](#example-usage)
 
 ## Action Inputs
 
-## `datatrails-client_id`
+### `content-type`
+
+**Required** The payload content type (iana mediaType) to be registered on the SCITT Service (eg: application/spdx+json, application/vnd.cyclonedx+json, Scan Result, Attestation)
+
+### `datatrails-client_id`
 
 **Required** The `CLIENT_ID` used to access the DataTrails SCITT APIs
 
-## `datatrails-secret`
+### `datatrails-secret`
 
 **Required** The `SECRET` used to access the DataTrails SCITT APIs
 
-## `subject`
+### `payload-file`
 
-**Required** Unique ID for the collection of statements about an artifact. For more info, see `subject` in the [IETF SCITT Terminology](https://datatracker.ietf.org/doc/html/draft-ietf-scitt-architecture#name-terminology).
+**Required** The payload file to be registered on the SCITT Service (eg: SBOM, Scan Result, Attestation)
 
-### `payload`
+### `payload-location`
 
-**Required** The payload file to be registered on the SCITT Service (SBOM, Scan Result, Attestation, etc.)
+**Optional** Location the content of the payload may be stored.
 
-### `content-type`
+### `receipt-file`
 
-**Required** The payload content type (IANA media type) to be registered on the SCITT Service. For example: `application/spdx+json`
+**Optional** The filename to save the cbor receipt
+**Default** 'receipt.cbor'
 
 ### `signed-statement-file`
 
-**Optional** A required file representing the signed SCITT Statement that will be registered with the SCITT Transparency Service. The parameter is optional, as it provides a default file name.  
+**Optional** A required file representing the signed SCITT Statement that will be registered with the SCITT Transparency Service.
+The parameter is optional, as it provides a default file name.  
 See [Signed Statement Issuance and Registration](https://datatracker.ietf.org/doc/html/draft-ietf-scitt-architecture#name-signed-statement-issuance-a)
 **Default** 'signed-statement.cbor'
 
+### `skip-receipt`
+
+**Optional** To skip receipt retrieval, set to 1
+**Default** '0'
+
+### `subject`
+
+**Required** Unique ID for the collection of statements about an artifact.
+For more info, see `subject` in the [IETF SCITT Terminology](https://datatracker.ietf.org/doc/html/draft-ietf-scitt-architecture#name-terminology).
+
 ## Secrets
 
-This action requires secrets containing credentials and keypair information be configured. Specifically, the following secrets are required:
+This action requires secrets containing credentials and keypair information be configured.
+Specifically, the following secrets are required:
 
 ### DIGICERT_STM_CERTIFICATE_ID
 
@@ -107,16 +129,24 @@ jobs:
         # A sample compliance file. Replace with an SBOM, in-toto statement, image for content authenticity, ...
         run: |
           echo '{"author": "fred", "title": "my biography", "reviews": "mixed"}' > ./buildOutput/attestation.json
-      - name: Register as a SCITT Signed Statement
-         # Register the Signed Statement with DataTrails SCITT APIs
-        id: register-compliance-scitt-signed-statement
-        uses: digicert/scitt-action@v0.2
+      - name: Upload Attestation
+        id: upload-attestation
+        uses: actions/upload-artifact@v4
         with:
+          name: attestation.json
+          path: ./buildOutput/attestation.json
+      - name: Sign & Register as a SCITT Signed Statement
+         # Register the DigiCert Signed Statement with the DataTrails SCITT APIs
+        id: register-compliance-scitt-signed-statement
+        uses: digicert/scitt-action@v0.3
+        with:
+          content-type: "application/vnd.unknown.attestation+json"
           datatrails-client_id: ${{ env.DATATRAILS_CLIENT_ID }}
           datatrails-secret: ${{ env.DATATRAILS_SECRET }}
-          subject: ${{ github.server_url }}/${{ github.repository }}@${{ github.sha }}
-          payload: "./buildOutput/attestation.json"
-          content-type: "application/vnd.unknown.attestation+json"
+          payload-file: "./buildOutput/attestation.json"
+          payload-location: ${{ steps.upload-attestation.outputs.artifact-url }}
+          subject: "ghcr.io/${{ github.repository }}:${{ github.sha }}"
+          skip-receipt: "0"
       - name: upload-signed-statement
         uses: actions/upload-artifact@v4
         with:

--- a/action.yml
+++ b/action.yml
@@ -1,29 +1,36 @@
 name: 'DataTrails SCITT API'
 description: 'Register, Get Receipts and Query Feeds from the DataTrails SCITT API'
 inputs:
+  content-type:
+    description: 'The payload content type (iana mediaType) to be registered on the SCITT Service (eg: application/spdx+json, application/vnd.cyclonedx+json, Scan Result, Attestation)'
+    required: true
   datatrails-client_id:
     description: 'The CLIENT_ID used to access the DataTrails SCITT APIs'
     required: true
   datatrails-secret:
     description: 'The SECRET used to access the DataTrails SCITT APIs'
     required: true
-  subject:
-    description: 'Unique ID for the collection of statements about an artifact'
-    required: true
-  payload:
+  payload-file:
     description: 'The payload file to be registered on the SCITT Service (eg: SBOM, Scan Result, Attestation)'
     required: true
-  content-type:
-    description: 'The payload content type (iana mediaType) to be registered on the SCITT Service (eg: application/spdx+json, application/vnd.cyclonedx+json, Scan Result, Attestation)'
-    required: true
+  payload-location:
+    description: 'Optional location the content of the payload may be stored.'
+    required: false
+  receipt-file:
+    description: 'The filename to save the cbor receipt'
+    required: false
+    default: 'receipt.cbor'
   signed-statement-file:
     description: 'File representing the signed SCITT Statement that will be registered on SCITT.'
     required: false
     default: 'signed-statement.cbor'
-  receipt-file:
-    description: 'The file to save the cbor receipt'
+  skip-receipt:
+    description: 'To skip receipt retrieval, set to 1'
     required: false
-    default: 'receipt.cbor'
+    default: '0'
+  subject:
+    description: 'Unique ID for the collection of statements about an artifact'
+    required: true
 outputs:
   token: # id of output
     description: 'the token used to authenticate'
@@ -31,10 +38,12 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
+    - ${{ inputs.content-type }}
     - ${{ inputs.datatrails-client_id }}
     - ${{ inputs.datatrails-secret }}
-    - ${{ inputs.subject }}
-    - ${{ inputs.payload }}
-    - ${{ inputs.content-type }}
-    - ${{ inputs.signed-statement-file }}
+    - ${{ inputs.payload-file }}
+    - ${{ inputs.payload-location}}
     - ${{ inputs.receipt-file }}
+    - ${{ inputs.signed-statement-file }}
+    - ${{ inputs.skip-receipt }}
+    - ${{ inputs.subject }}

--- a/scitt-scripts/check_operation_status.py
+++ b/scitt-scripts/check_operation_status.py
@@ -2,6 +2,8 @@
 
 import os
 import argparse
+import logging
+import sys
 
 from time import sleep as time_sleep
 
@@ -10,7 +12,7 @@ import requests
 
 # all timeouts and durations are in seconds
 REQUEST_TIMEOUT = 30
-POLL_TIMEOUT = 360
+POLL_TIMEOUT = 60
 POLL_INTERVAL = 10
 
 
@@ -39,10 +41,7 @@ def get_operation_status(operation_id: str, headers: dict) -> dict:
 
     while True:
         response = requests.get(url, timeout=30, headers=headers)
-        # print("***response:", flush=True)
-        # print(response, flush=True)
-        # print(response.json, flush=True)
-        # print("***response:", flush=True)
+
         if response.status_code == 200:
             break
         elif response.status_code == 400:
@@ -53,33 +52,40 @@ def get_operation_status(operation_id: str, headers: dict) -> dict:
     return response.json()
 
 
-def poll_operation_status(operation_id: str, headers: dict) -> str:
+def poll_operation_status(
+    operation_id: str, headers: dict, logger: logging.Logger
+) -> str:
     """
     polls for the operation status to be 'succeeded'.
     """
 
     poll_attempts: int = int(POLL_TIMEOUT / POLL_INTERVAL)
 
-    for _ in range(poll_attempts):
-        operation_status = get_operation_status(operation_id, headers)
-        # print("***operation_status:", flush=True)
-        # print(operation_status, flush=True)
-        # print("***operation_status:", flush=True)
+    logger.info("starting to poll for operation status 'succeeded'")
 
-        # pylint: disable=fixme
-        # TODO: ensure get_operation_status handles error cases from the rest request
-        if "status" in operation_status and operation_status["status"] == "succeeded":
-            return operation_status["entryID"]
+    for _ in range(poll_attempts):
+
+        try:
+            operation_status = get_operation_status(operation_id, headers)
+
+            # pylint: disable=fixme
+            # TODO: ensure get_operation_status handles error cases from the rest request
+            if (
+                "status" in operation_status
+                and operation_status["status"] == "succeeded"
+            ):
+                return operation_status["entryID"]
+
+        except requests.HTTPError as e:
+            logger.debug("failed getting operation status, error: %s", e)
 
         time_sleep(POLL_INTERVAL)
 
-    raise TimeoutError("signed statement not registered within polling duration.")
+    raise TimeoutError("signed statement not registered within polling duration")
 
 
 def main():
     """Polls for the signed statement to be registered"""
-
-    # print("*****in-main*****", flush=True)
 
     parser = argparse.ArgumentParser(
         description="Polls for the signed statement to be registered"
@@ -108,21 +114,27 @@ def main():
         default=default_token_file_name,
     )
 
+    # log level
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        help="log level. for any individual poll errors use DEBUG, defaults to WARNING",
+        default="WARNING",
+    )
+
     args = parser.parse_args()
 
-    # print("args.token_file_name:", flush=True)
-    # print(args.token_file_name, flush=True)
+    logger = logging.getLogger("check operation status")
+    logging.basicConfig(level=logging.getLevelName(args.log_level))
 
     headers = get_token_from_file(args.token_file_name)
-    # print("headers:", flush=True)
-    # print(headers, flush=True)
 
-    # print("operation_id:", flush=True)
-    # print(args.operation_id, flush=True)
-
-    entry_id = poll_operation_status(args.operation_id, headers)
-    print(entry_id, flush=True)
-
+    try:
+        entry_id = poll_operation_status(args.operation_id, headers, logger)
+        print(entry_id)
+    except TimeoutError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/scitt-scripts/entrypoint.sh
+++ b/scitt-scripts/entrypoint.sh
@@ -1,49 +1,92 @@
 #!/bin/bash -l
 
-# echo "datatrails-client_id:    " ${1}
-# echo "datatrails-secret:       " ${2}
-# echo "subject:                 " ${3}
-# echo "payload:                 " ${4}
-# echo "content-type:            " ${5}
-# echo "signed-statement-file:   " ${6}
-# echo "receipt-file:            " ${7}
+set -e
 
-SIGNED_STATEMENT_FILE=./${6}
+# echo "content-type:            " ${1}
+# echo "datatrails-client_id:    " ${2}
+# echo "datatrails-secret:       " ${3}
+# echo "payload-file:            " ${4}
+# echo "payload-location:        " ${5}
+# echo "receipt-file:            " ${6}
+# echo "signed-statement-file:   " ${7}
+# echo "skip-receipt:            " ${8}
+# echo "subject:                 " ${9}
+
+CONTENT_TYPE=${1}
+DATATRAILS_CLIENT_ID=${2}
+DATATRAILS_SECRET_ID=${3}
+PAYLOAD_FILE=${4}
+PAYLOAD_LOCATION=${5}
+RECEIPT_FILE=${6}
+SIGNED_STATEMENT_FILE=${7}
+SKIP_RECEIPT=${8}
+SUBJECT=${9}
+
 TOKEN_FILE="./bearer-token.txt"
-SUBJECT=${3}
+
+if [ ! -f $PAYLOAD_FILE ]; then
+  echo "ERROR: Payload File: [$PAYLOAD_FILE] Not found!"
+  exit 126
+fi
 
 # echo "Create an access token"
-/scripts/create-token.sh ${1} ${2} $TOKEN_FILE
+/scripts/create-token.sh ${DATATRAILS_CLIENT_ID} ${DATATRAILS_SECRET_ID} $TOKEN_FILE
+
+if [ ! -f $TOKEN_FILE ]; then
+  echo "ERROR: Token File: [$TOKEN_FILE] Not found!"
+  exit 126
+fi
 
 echo "Sign a SCITT Statement with key protected in DigiCert Software Trust Manager"
 
 python /scripts/create_signed_statement.py \
-  --subject ${3} \
-  --payload-file ${4} \
-  --content-type ${5} \
+  --content-type $CONTENT_TYPE \
+  --payload-file $PAYLOAD_FILE \
+  --payload-location $PAYLOAD_LOCATION \
+  --subject $SUBJECT \
   --output-file $SIGNED_STATEMENT_FILE
 
-echo "SCITT Register to https://app.datatrails.ai/archivist/v1/publicscitt/entries"
+if [ ! -f $SIGNED_STATEMENT_FILE ]; then
+  echo "ERROR: Signed Statement: [$SIGNED_STATEMENT_FILE] Not found!"
+  exit 126
+fi
 
-OPERATION_ID=$(curl -X POST -H @$TOKEN_FILE \
+echo "Register the SCITT Signed Statement to https://app.datatrails.ai/archivist/v1/publicscitt/entries"
+
+RESPONSE=$(curl -X POST -H @$TOKEN_FILE \
                 --data-binary @$SIGNED_STATEMENT_FILE \
-                https://app.datatrails.ai/archivist/v1/publicscitt/entries | jq -r .operationID)
+                https://app.datatrails.ai/archivist/v1/publicscitt/entries)
 
-echo "OPERATION_ID :" $OPERATION_ID
+echo "RESPONSE: $RESPONSE"
 
-echo "Wait for ledger anchoring to be complete"
+OPERATION_ID=$(echo $RESPONSE | jq  -r .operationID)
+echo "OPERATION_ID: $OPERATION_ID"
 
-echo "call: /scripts/check_operation_status.py"
-python /scripts/check_operation_status.py --operation-id $OPERATION_ID --token-file-name $TOKEN_FILE
+if [ ${#OPERATION_ID} -lt 1 ]; then
+  echo "error: OPERATION_ID not found. POST to https://app.datatrails.ai/archivist/v1/publicscitt/entries failed"
+  exit 126
+fi
 
-echo "Get the ENTRY_ID: $ENTRY_ID"
+echo "skip-receipt: $SKIP_RECEIPT"
 
-ENTRY_ID=$(python /scripts/check_operation_status.py --operation-id $OPERATION_ID --token-file-name $TOKEN_FILE)
-echo "ENTRY_ID :" $ENTRY_ID
+if [ -n "$SKIP_RECEIPT" ] && [ $SKIP_RECEIPT = "1" ]; then
+  echo "skipping receipt retrieval"
+else
+  echo "Download the SCITT Receipt: $RECEIPT_FILE"
+  echo "call: /scripts/check_operation_status.py"
+  python /scripts/check_operation_status.py --operation-id $OPERATION_ID --token-file-name $TOKEN_FILE
 
-echo "Download the SCITT Receipt: $7"
+  ENTRY_ID=$(python /scripts/check_operation_status.py --operation-id $OPERATION_ID --token-file-name $TOKEN_FILE)
+  echo "ENTRY_ID :" $ENTRY_ID
 
-curl -H @$TOKEN_FILE \
-  https://app.datatrails.ai/archivist/v1/publicscitt/entries/$ENTRY_ID/receipt \
-  -o $7
-# curl https://app.datatrails.ai/archivist/v2/publicassets/-/events?event_attributes.feed_id=$SUBJECT | jq
+  if [ ${#ENTRY_ID} -lt 1 ]; then
+    echo "error: ENTRY_ID not found. check_operation_status.py failed"
+    exit 126
+  fi
+
+  curl -H @$TOKEN_FILE \
+    https://app.datatrails.ai/archivist/v1/publicscitt/entries/$ENTRY_ID/receipt \
+    -o $RECEIPT_FILE
+fi
+
+# curl https://app.datatrails.ai/archivist/v2/publicassets/-/events?event_attributes.subject=$SUBJECT | jq

--- a/scitt-scripts/requirements.txt
+++ b/scitt-scripts/requirements.txt
@@ -2,6 +2,6 @@
 pycose~=1.0.1
 ecdsa~=0.18.0
 jwcrypto~=1.5.0
-requests~=2.31.0
+requests>=2.32.0
 requests-pkcs12~=1.24
 cryptography~=42.0.2


### PR DESCRIPTION
* Add receipt retreival, cleanup debugging info



* Fix token file reference



* Add sample for the SCITT Action



* Add skip-receipt



* Add skip-receipt



* Fix parameter reference for skip-receipt



* Add file error handling



* Fix parameter reference for skip-receipt



* Test curl errors



* Test curl errors



* Change to signed statements of hashed payloads



* Merge hashed payloads to digicert signed statements



* Update numbered to named variables



* Fix param ordering



* Enable debugging



* Name parameters



* Name parameters



* Add receipt handling



* Update HEADER parameters for private use



* Readme sample updates



* Comment out debugging output



* Change return to exit for error handling



* Add more error handling



* Add COSE Type



* Fix call to generate a receipt



* Add PREVIEW heading



* Add error handling for check-operation-status



* Add error handling for check-operation-status



* Remove duplicative lines



* PR Feedback



---------